### PR TITLE
fix(pkgdown): add tech-mix exports to reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -95,6 +95,7 @@ reference:
   - pipeline_trisk_expected_loss_plot
   - pipeline_trisk_exposure_change_plot
   - pipeline_trisk_npv_change_plot
+  - pipeline_trisk_tech_mix
   - plot_multi_trajectories
 
 - title: Plot styling
@@ -102,3 +103,5 @@ reference:
   contents:
   - TRISK_PLOT_THEME_FUNC
   - trisk_palette
+  - TRISK_SECTOR_PALETTE
+  - trisk_sector_shades


### PR DESCRIPTION
Adds the three new exports (pipeline_trisk_tech_mix, TRISK_SECTOR_PALETTE, trisk_sector_shades) to _pkgdown.yml. Without them build_reference_index() errors and the docs deploy fails (broke after #51). Verified: all 44 exported topics now referenced.